### PR TITLE
Maintain order of key value pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.1] - 2023-01-29
+## [1.0.1] - 2023-01-30
 ### Fixed
+- When creating a `Query` from string, and it contains empty key value parts, like `&foo=bar`, `foo=bar&` or `foo=bar&&baz=quz`, the unnecessary `&` characters are removed in the string version now. For example, `&foo=bar` previously lead to `$instance->toString()` returning `&foo=bar` and now it returns `foo=bar`.
+- To assure that there can't be differences in the array and string versions returned by the `Query` class, no matter if the instance was created from string or array, the library now first converts incoming values back and forth. So, when an instance is created from string, it first converts it to an array and then again back to a string and vice versa when an instance is created from an array. Some Examples being fixed by this:
+  - From string `   foo=bar  `:
+    - Before: toString(): `+++foo=bar++`, toArray(): `['foo' => 'bar  ']`.
+    - Now: toString(): `foo=bar++`, toArray(): `['foo' => 'bar  ']`
+  - From string `foo[bar] [baz]=bar`
+    - Before: toString(): `foo%5Bbar%5D+%5Bbaz%5D=bar`, toArray(): `['foo' => ['bar' => 'bar']]`.
+    - Now: toString(): `foo%5Bbar%5D=bar`, toArray(): `'[foo' => ['bar' => 'bar']]`.
+  - From string `foo[bar][baz][]=bar&foo[bar][baz][]=foo`
+    - Before: toString(): `foo%5Bbar%5D%5Bbaz%5D%5B%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B%5D=foo`, toArray(): `['foo' => ['bar' => ['baz' => ['bar', 'foo']]]]`.
+    - Now: toString(): `foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo`, toArray(): `['foo' => ['bar' => ['baz' => ['bar', 'foo']]]]`.
+  - From string `option`
+    - Before: toString(): `option`, toArray(): `['option' => '']`
+    - Now: toString(): `option=`, toArray(): `['option' => '']`
+  - From string `foo=bar=bar==`
+    - Before: toString(): `foo=bar=bar==`, toArray(): `[['foo' => 'bar=bar==']`
+    - Now: toString(): `foo=bar%3Dbar%3D%3D`, toArray(): `[['foo' => 'bar=bar==']`
+  - From string `sum=10%5c2%3d5`
+    - Before: toString(): `sum=10%5c2%3d5`, toArray(): `[['sum' => '10\\2=5']`
+    - Now: toString(): `sum=10%5C2%3D5`, toArray(): `[['sum' => '10\\2=5']`
+  - From string `foo=%20+bar`
+    - Before: toString(): `foo=%20+bar`, toArray(): `['foo' => '  bar']`
+    - Now: toString(): `foo=++bar`, toArray(): `['foo' => '  bar']`
 - Maintain the correct order of key value pairs when converting query string to array.

--- a/tests/FromArrayTest.php
+++ b/tests/FromArrayTest.php
@@ -28,3 +28,119 @@ it('handles encoding', function () {
 
     expect($queryString->toArray())->toBe(['föó' => 'bär']);
 });
+
+it('sanitizes array input', function () {
+    $queryString = Query::fromArray(['   foo' => 'bar  ']);
+
+    expect($queryString->toArray())->toBe(['foo' => 'bar  ']);
+
+    expect($queryString->toString())->toBe('foo=bar++');
+});
+
+it(
+    // See https://github.com/brefphp/bref/pull/1383
+    'correctly handles all the test cases from bref, related to keys containing dots',
+    function (array $queryArray, string $expectedQueryString) {
+        $queryString = Query::fromArray($queryArray);
+
+        expect($queryString->toString())->toBe($expectedQueryString);
+    }
+)->with([
+    [['foo' => 'bar', 'baz.bar' => 'foo'], 'foo=bar&baz.bar=foo'],
+    [
+        [
+            'foo' => ['bar', 'baz'],
+            'cards' => ['birthday'],
+            'colors' => [['red'], ['blue']],
+            'shapes' => ['a' => ['square', 'triangle']],
+            'myvar' => 'abc',
+            'foo.bar' => ['baz'],
+        ],
+        'foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue' .
+        '&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz',
+    ],
+    [
+        [
+            'vars' => [
+                'val1' => 'foo',
+                'val2' => ['bar'],
+            ],
+            'foo.bar' => ['baz'],
+        ],
+        'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar&foo.bar%5B0%5D=baz',
+    ],
+    [
+        ['foo_bar' => '2'],
+        'foo_bar=2',
+    ],
+    [
+        ['foo_bar' => 'v1', 'foo.bar' => 'v2'],
+        'foo_bar=v1&foo.bar=v2',
+    ],
+    [
+        ['foo_bar' => 'v1', 'foo.bar' => 'v2', 'foo.bar_extra' => 'v3', 'foo_bar3' => 'v4'],
+        'foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',
+    ],
+    [
+        ['foo_bar.baz' => 'v1'],
+        'foo_bar.baz=v1',
+    ],
+    [
+        ['foo_bar' => 'v1', 'k' => ['foo.bar' => 'v2']],
+        'foo_bar=v1&k%5Bfoo.bar%5D=v2',
+    ],
+    [
+        ['k.1' => 'v.1', 'k.2' => ['s.k1' => 'v.2', 's.k2' => 'v.3']],
+        'k.1=v.1&k.2%5Bs.k1%5D=v.2&k.2%5Bs.k2%5D=v.3',
+    ],
+    [
+        ['foo.bar' => ['v1'], 'foo.bar_extra' => ['v2'], 'foo.bar.extra' => ['v3']],
+        'foo.bar%5B0%5D=v1&foo.bar_extra%5B0%5D=v2&foo.bar.extra%5B0%5D=v3',
+    ],
+
+    // test cases from FromStringTest, reversed
+    [['foo' => 'bar'], 'foo=bar'],
+    [['foo' => 'bar  '], 'foo=bar++'],
+    [['?foo' => 'bar'], '%3Ffoo=bar'],
+    [['#foo' => 'bar'], '%23foo=bar'],
+    [['foo' => 'bar'], 'foo=bar'],
+    [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo'],
+    [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo'],
+    [['foo' => ['bar' => ['baz' => ['bax' => 'bar']]]], 'foo%5Bbar%5D%5Bbaz%5D%5Bbax%5D=bar'],
+    [['foo' => ['bar' => 'bar']], 'foo%5Bbar%5D=bar'],
+    [['foo' => ['bar' => ['baz' => ['bar', 'foo']]]], 'foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo'],
+    [['foo' => ['bar' => [['bar'], ['foo']]]], 'foo%5Bbar%5D%5B0%5D%5B0%5D=bar&foo%5Bbar%5D%5B1%5D%5B0%5D=foo'],
+    [['option' => ''], 'option='],
+    [['option' => '0'], 'option=0'],
+    [['option' => '1'], 'option=1'],
+    [['foo' => 'bar=bar=='], 'foo=bar%3Dbar%3D%3D'],
+    [['options' => ['option' => '0']], 'options%5Boption%5D=0'],
+    [['options' => ['option' => 'foobar']], 'options%5Boption%5D=foobar'],
+    [['sum' => '10\\2=5'], 'sum=10%5C2%3D5'],
+    // Special cases
+    [
+        [
+            'a' => '<==  foo bar  ==>',
+            'b' => '###Hello World###',
+        ],
+        'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+    ],
+    [
+        ['str' => "A string with containing \0\0\0 nulls"],
+        'str=A+string+with+containing+%00%00%00+nulls',
+    ],
+    [
+        [
+            'arr_1' => 'sid',
+            'arr' => ['4' => 'fred'],
+        ],
+        'arr_1=sid&arr%5B4%5D=fred',
+    ],
+    [
+        [
+            'arr_1' => 'sid',
+            'arr' => ['4' => ['[2' => 'fred']],
+        ],
+        'arr_1=sid&arr%5B4%5D%5B%5B2%5D=fred',
+    ],
+]);

--- a/tests/FromStringTest.php
+++ b/tests/FromStringTest.php
@@ -67,3 +67,114 @@ it('maintains the correct order of key value pairs', function () {
         'foo_bar3' => 'v4',
     ]);
 });
+
+it(
+    // See https://github.com/brefphp/bref/pull/1383
+    'correctly handles all the test cases from bref, related to keys containing dots',
+    function (array $array, string $normalized, string $raw) {
+        $query = Query::fromString($raw);
+
+        expect($query->toString())->toBe($normalized);
+
+        expect($query->toArray())->toBe($array);
+    }
+)->with([
+    [['foo' => 'bar'], 'foo=bar', 'foo=bar'],
+    [['foo' => 'bar  '], 'foo=bar++', '   foo=bar  '],
+    [['?foo' => 'bar'], '%3Ffoo=bar', '?foo=bar'],
+    [['#foo' => 'bar'], '%23foo=bar', '#foo=bar'],
+    [['foo' => 'bar'], 'foo=bar', '&foo=bar'],
+    [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&bar=foo'],
+    [['foo' => 'bar', 'bar' => 'foo'], 'foo=bar&bar=foo', 'foo=bar&&bar=foo'],
+    [['foo' => ['bar' => ['baz' => ['bax' => 'bar']]]], 'foo%5Bbar%5D%5Bbaz%5D%5Bbax%5D=bar', 'foo[bar][baz][bax]=bar'],
+    [['foo' => ['bar' => 'bar']], 'foo%5Bbar%5D=bar', 'foo[bar] [baz]=bar'],
+    [
+        ['foo' => ['bar' => ['baz' => ['bar', 'foo']]]],
+        'foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo',
+        'foo[bar][baz][]=bar&foo[bar][baz][]=foo',
+    ],
+    [['foo' => ['bar' => [['bar'], ['foo']]]], 'foo%5Bbar%5D%5B0%5D%5B0%5D=bar&foo%5Bbar%5D%5B1%5D%5B0%5D=foo', 'foo[bar][][]=bar&foo[bar][][]=foo'],
+    [['option' => ''], 'option=', 'option'],
+    [['option' => '0'], 'option=0', 'option=0'],
+    [['option' => '1'], 'option=1', 'option=1'],
+    [['foo' => 'bar=bar=='], 'foo=bar%3Dbar%3D%3D', 'foo=bar=bar=='],
+    [['options' => ['option' => '0']], 'options%5Boption%5D=0', 'options[option]=0'],
+    [['options' => ['option' => 'foobar']], 'options%5Boption%5D=foobar', 'options[option]=foobar'],
+    [['sum' => '10\\2=5'], 'sum=10%5C2%3D5', 'sum=10%5c2%3d5'],
+
+    // Special cases
+    [
+        [
+            'a' => '<==  foo bar  ==>',
+            'b' => '###Hello World###',
+        ],
+        'a=%3C%3D%3D++foo+bar++%3D%3D%3E&b=%23%23%23Hello+World%23%23%23',
+        'a=%3c%3d%3d%20%20foo+bar++%3d%3d%3e&b=%23%23%23Hello+World%23%23%23',
+    ],
+    [
+        ['str' => "A string with containing \0\0\0 nulls"],
+        'str=A+string+with+containing+%00%00%00+nulls',
+        'str=A%20string%20with%20containing%20%00%00%00%20nulls',
+    ],
+    [
+        [
+            'arr_1' => 'sid',
+            'arr' => ['4' => 'fred'],
+        ],
+        'arr_1=sid&arr%5B4%5D=fred',
+        'arr[1=sid&arr[4][2=fred',
+    ],
+    [
+        [
+            'arr_1' => 'sid',
+            'arr' => ['4' => ['[2' => 'fred']],
+        ],
+        'arr_1=sid&arr%5B4%5D%5B%5B2%5D=fred',
+        'arr[1=sid&arr[4][[2][3[=fred',
+    ],
+
+    // Test cases from FromArrayTest, reversed
+    [['foo' => 'bar', 'baz.bar' => 'foo'], 'foo=bar&baz.bar=foo', 'foo=bar&baz.bar=foo'],
+    [
+        [
+            'foo' => ['bar', 'baz'],
+            'cards' => ['birthday'],
+            'colors' => [['red'], ['blue']],
+            'shapes' => ['a' => ['square', 'triangle']],
+            'myvar' => 'abc',
+            'foo.bar' => ['baz'],
+        ],
+        'foo%5B0%5D=bar&foo%5B1%5D=baz&cards%5B0%5D=birthday&colors%5B0%5D%5B0%5D=red&colors%5B1%5D%5B0%5D=blue' .
+        '&shapes%5Ba%5D%5B0%5D=square&shapes%5Ba%5D%5B1%5D=triangle&myvar=abc&foo.bar%5B0%5D=baz',
+        'foo[0]=bar&foo[1]=baz&cards[0]=birthday&colors[0][0]=red&colors[1][0]=blue&shapes[a][0]=square' .
+        '&shapes[a][1]=triangle&myvar=abc&foo.bar[0]=baz',
+    ],
+    [
+        ['vars' => ['val1' => 'foo', 'val2' => ['bar']], 'foo.bar' => ['baz']],
+        'vars%5Bval1%5D=foo&vars%5Bval2%5D%5B0%5D=bar&foo.bar%5B0%5D=baz',
+        'vars[val1]=foo&vars[val2][0]=bar&foo.bar[0]=baz',
+    ],
+    [['foo_bar' => '2'], 'foo_bar=2', 'foo_bar=2'],
+    [['foo_bar' => 'v1', 'foo.bar' => 'v2'], 'foo_bar=v1&foo.bar=v2', 'foo_bar=v1&foo.bar=v2'],
+    [
+        ['foo_bar' => 'v1', 'foo.bar' => 'v2', 'foo.bar_extra' => 'v3', 'foo_bar3' => 'v4'],
+        'foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',
+        'foo_bar=v1&foo.bar=v2&foo.bar_extra=v3&foo_bar3=v4',
+    ],
+    [['foo_bar.baz' => 'v1'], 'foo_bar.baz=v1', 'foo_bar.baz=v1'],
+    [
+        ['foo_bar' => 'v1', 'k' => ['foo.bar' => 'v2']],
+        'foo_bar=v1&k%5Bfoo.bar%5D=v2',
+        'foo_bar=v1&k[foo.bar]=v2',
+    ],
+    [
+        ['k.1' => 'v.1', 'k.2' => ['s.k1' => 'v.2', 's.k2' => 'v.3']],
+        'k.1=v.1&k.2%5Bs.k1%5D=v.2&k.2%5Bs.k2%5D=v.3',
+        'k.1=v.1&k.2[s.k1]=v.2&k.2[s.k2]=v.3',
+    ],
+    [
+        ['foo.bar' => ['v1'], 'foo.bar_extra' => ['v2'], 'foo.bar.extra' => ['v3']],
+        'foo.bar%5B0%5D=v1&foo.bar_extra%5B0%5D=v2&foo.bar.extra%5B0%5D=v3',
+        'foo.bar[0]=v1&foo.bar_extra[0]=v2&foo.bar.extra[0]=v3',
+    ],
+]);


### PR DESCRIPTION
- When creating a `Query` from string, and it contains empty key value parts, like `&foo=bar`, `foo=bar&` or `foo=bar&&baz=quz`, the unnecessary `&` characters are removed in the string version now. For example, `&foo=bar` previously lead to `$instance->toString()` returning `&foo=bar` and now it returns `foo=bar`.
- To assure that there can't be differences in the array and string versions returned by the `Query` class, no matter if the instance was created from string or array, the library now first converts incoming values back and forth. So, when an instance is created from string, it first converts it to an array and then again back to a string and vice versa when an instance is created from an array. Some Examples being fixed by this:
  - From string `   foo=bar  `:
    - Before: toString(): `+++foo=bar++`, toArray(): `['foo' => 'bar  ']`.
    - Now: toString(): `foo=bar++`, toArray(): `['foo' => 'bar  ']`
  - From string `foo[bar] [baz]=bar`
    - Before: toString(): `foo%5Bbar%5D+%5Bbaz%5D=bar`, toArray(): `['foo' => ['bar' => 'bar']]`.
    - Now: toString(): `foo%5Bbar%5D=bar`, toArray(): `'[foo' => ['bar' => 'bar']]`.
  - From string `foo[bar][baz][]=bar&foo[bar][baz][]=foo`
    - Before: toString(): `foo%5Bbar%5D%5Bbaz%5D%5B%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B%5D=foo`, toArray(): `['foo' => ['bar' => ['baz' => ['bar', 'foo']]]]`.
    - Now: toString(): `foo%5Bbar%5D%5Bbaz%5D%5B0%5D=bar&foo%5Bbar%5D%5Bbaz%5D%5B1%5D=foo`, toArray(): `['foo' => ['bar' => ['baz' => ['bar', 'foo']]]]`.
  - From string `option`
    - Before: toString(): `option`, toArray(): `['option' => '']`
    - Now: toString(): `option=`, toArray(): `['option' => '']`
  - From string `foo=bar=bar==`
    - Before: toString(): `foo=bar=bar==`, toArray(): `[['foo' => 'bar=bar==']`
    - Now: toString(): `foo=bar%3Dbar%3D%3D`, toArray(): `[['foo' => 'bar=bar==']`
  - From string `sum=10%5c2%3d5`
    - Before: toString(): `sum=10%5c2%3d5`, toArray(): `[['sum' => '10\\2=5']`
    - Now: toString(): `sum=10%5C2%3D5`, toArray(): `[['sum' => '10\\2=5']`
  - From string `foo=%20+bar`
    - Before: toString(): `foo=%20+bar`, toArray(): `['foo' => '  bar']`
    - Now: toString(): `foo=++bar`, toArray(): `['foo' => '  bar']`
- Maintain the correct order of key value pairs when converting query string to array.