### PR TITLE
Fix bug introduced in v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2023-04-12
+### Fixed
+- Fixes an issue introduced in v1.0.2. When creating an instance from string, it's containing an array and the brackets are encoded (like `filter%5Bfoo%5D%5B%5D=1&filter%5Bfoo%5D%5B%5D=2`), the method trying to fix duplicate keys without brackets added another array level (like `filter[foo][]` to `filter[foo][][]`). This is fixed with this release.
+
 ## [1.0.2] - 2023-04-12
 ### Fixed
 - Duplicate keys without array notation (like `foo=bar&foo=baz`) are now also interpreted as array (like `foo[]=bar&foo[]=baz`). This is considered a bugfix because:

--- a/src/Query.php
+++ b/src/Query.php
@@ -1019,6 +1019,8 @@ final class Query implements ArrayAccess, Iterator
         $keyOccurrences = array_count_values(array_map(fn ($val) => explode('=', $val, 2)[0], explode('&', $query)));
 
         foreach ($keyOccurrences as $key => $count) {
+            $key = $this->toStringWithUnencodedBrackets($key);
+
             if ($count > 1 && !str_contains($key, '[')) {
                 // Duplicate query string key without array notation, convert to {keyName}[] structure
                 $query = preg_replace(

--- a/tests/FromStringTest.php
+++ b/tests/FromStringTest.php
@@ -186,3 +186,15 @@ test('Duplicate query string keys are converted to arrays', function () {
             'test2' => 2,
         ]);
 });
+
+it('correctly parses array syntax when brackets are encoded', function () {
+    expect(
+        Query::fromString(
+            'filter%5Bdestination%5D%5B%5D=101&filter%5Bdestination%5D%5B%5D=103&filter%5Bdestination%5D%5B%5D=106'
+        )->toArray()
+    )->toBe([
+        'filter' => [
+            'destination' => ['101', '103', '106']
+        ]
+    ]);
+});


### PR DESCRIPTION
Fixes an issue introduced in v1.0.2. When creating an instance from string, it's containing an array and the brackets are encoded (like `filter%5Bfoo%5D%5B%5D=1&filter%5Bfoo%5D%5B%5D=2`), the method trying to fix duplicate keys without brackets added another array level (like `filter[foo][]` to `filter[foo][][]`). This is fixed with this release.