### PR TITLE
Run tests also in PHP 8.3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI (tests, static analysis and code style)
+name: CI
 
 on: pull_request
 
@@ -9,18 +9,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
 
-      - name: Check PHP Version
-        run: php -v
-
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run PHP CS Fixer
         run: composer cs
@@ -30,22 +27,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
 
-      - name: Check PHP Version
-        run: php -v
-
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run tests
         run: vendor/bin/pest --coverage-clover clover.xml
@@ -56,18 +50,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
 
-      - name: Check PHP Version
-        run: php -v
-
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run PHPStan
         run: composer stan

--- a/tests/DirtyHookTest.php
+++ b/tests/DirtyHookTest.php
@@ -7,7 +7,7 @@ it('calls the dirty hook when set() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -23,7 +23,7 @@ it('calls the dirty hook when appendTo() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -39,7 +39,7 @@ it('calls the dirty hook when remove() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -55,7 +55,7 @@ it('calls the dirty hook when removeValueFrom() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -71,7 +71,7 @@ it('calls the dirty hook when filter() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -89,7 +89,7 @@ it('calls the dirty hook when map() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -107,7 +107,7 @@ it('calls the dirty hook when boolToString() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -123,7 +123,7 @@ it('calls the dirty hook when boolToInt() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -141,7 +141,7 @@ it('calls the dirty hook when spaceCharacterPercentTwenty() was called', functio
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -157,7 +157,7 @@ it('calls the dirty hook when spaceCharacterPlus() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -175,7 +175,7 @@ it('calls the dirty hook when separator() was called', function () {
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 
@@ -191,7 +191,7 @@ it('calls the dirty hook when something in a child Query instance was changed', 
 
     $hookWasCalled = false;
 
-    $query->setDirtyHook(function () use (& $hookWasCalled) {
+    $query->setDirtyHook(function () use (&$hookWasCalled) {
         $hookWasCalled = true;
     });
 


### PR DESCRIPTION
Further upgrade actions/checkout to v4, remove the deprecated --no-suggest option from composer install and some code style changes when running PHP CS Fixer with the latest version.